### PR TITLE
Use more secure password

### DIFF
--- a/seed_db_data.rb
+++ b/seed_db_data.rb
@@ -50,7 +50,7 @@ def create_admin(seq)
   User.new.tap { |admin|
     admin.email = "admin@fake#{seq}.appfolio.com"
     admin.username = "admin#{seq}"
-    admin.password = "password"
+    admin.password = "longpassword"
     admin.save!
     admin.grant_admin!
     admin.change_trust_level!(TrustLevel[4])


### PR DESCRIPTION
With latest discourse, I hit following 2 validation errors when executing seed_db_data.rb.

```
seed_db_data.rb: Validation failed: Password is too short (minimum is 10 characters) 
seed_db_data.rb: Validation failed: Password is one of the 10000 most common passwords. Please use a more secure password.
```

So I picked another password that was not invalidated.